### PR TITLE
bugfix(derive) implicit discriminants were wrongly calculated

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -20,3 +20,4 @@ proc-macro = true
 
 [dependencies]
 virtue = "0.0.15"
+evalexpr = "11.3.0"

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -30,9 +30,6 @@ impl DeriveEnum {
             let added_index = if variant_index > 0 {
                 let mut i = variant_index - 1;
                 loop {
-                    if i <= 0 {
-                        break false;
-                    }
                     let previous_variant = match self.variants.get(i) {
                         Some(v) => v,
                         None => {
@@ -43,9 +40,12 @@ impl DeriveEnum {
                         use std::str::FromStr;
                         let value_str = &value.span().source_text().unwrap_or("".to_string());
                         if let Ok(value) = u32::from_str(value_str) {
-                            builder.push_parsed((value + 1).to_string())?;
+                            builder.push_parsed((value + (variant_index - i) as u32).to_string())?;
                             break true;
                         }
+                    }
+                    if i <= 0 {
+                        break false;
                     }
                     i -= 1;
                 }

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -37,12 +37,15 @@ impl DeriveEnum {
                         }
                     };
                     if let Some(value) = &previous_variant.value {
-                        use std::str::FromStr;
                         let value_str = &value.span().source_text().unwrap_or("".to_string());
-                        if let Ok(value) = u32::from_str(value_str) {
-                            builder.push_parsed((value + (variant_index - i) as u32).to_string())?;
+                        let eval = evalexpr::eval(&format!("{} + {}",value_str, (variant_index - i) as u32));
+                        if let Ok(eval) = eval
+                        {
+                            builder.push_parsed(eval.to_string())?;
                             break true;
                         }
+                        
+                        
                     }
                     if i <= 0 {
                         break false;

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -253,62 +253,7 @@ fn test_decode_borrowed_enum_tuple_variant() {
     assert_eq!(len, 6);
 }
 
-#[derive(bincode::Decode, bincode::Encode, PartialEq, Eq, Debug)]
-enum CStyleEnum {
-    A = -1,
-    B = 2,
-    C,
-    D = 5,
-    E,
-}
 
-#[test]
-fn test_c_style_enum() {
-    fn ser(e: CStyleEnum) -> u8 {
-        let mut slice = [0u8; 10];
-        let bytes_written =
-            bincode::encode_into_slice(e, &mut slice, bincode::config::standard()).unwrap();
-        assert_eq!(bytes_written, 1);
-        slice[0]
-    }
-
-    assert_eq!(ser(CStyleEnum::A), 0);
-    assert_eq!(ser(CStyleEnum::B), 1);
-    assert_eq!(ser(CStyleEnum::C), 2);
-    assert_eq!(ser(CStyleEnum::D), 3);
-    assert_eq!(ser(CStyleEnum::E), 4);
-
-    fn assert_de_successfully(num: u8, expected: CStyleEnum) {
-        match bincode::decode_from_slice::<CStyleEnum, _>(&[num], bincode::config::standard()) {
-            Ok((result, len)) => {
-                assert_eq!(len, 1);
-                assert_eq!(result, expected)
-            }
-            Err(e) => panic!("Could not deserialize CStyleEnum idx {num}: {e:?}"),
-        }
-    }
-
-    fn assert_de_fails(num: u8) {
-        match bincode::decode_from_slice::<CStyleEnum, _>(&[num], bincode::config::standard()) {
-            Ok(_) => {
-                panic!("Expected to not be able to decode CStyleEnum index {num}, but it succeeded")
-            }
-            Err(DecodeError::UnexpectedVariant {
-                type_name: "CStyleEnum",
-                allowed: &bincode::error::AllowedEnumVariants::Allowed(&[0, 1, 2, 3, 4]),
-                found,
-            }) if found == num as u32 => {}
-            Err(e) => panic!("Expected DecodeError::UnexpectedVariant, got {e:?}"),
-        }
-    }
-
-    assert_de_successfully(0, CStyleEnum::A);
-    assert_de_successfully(1, CStyleEnum::B);
-    assert_de_successfully(2, CStyleEnum::C);
-    assert_de_successfully(3, CStyleEnum::D);
-    assert_de_successfully(4, CStyleEnum::E);
-    assert_de_fails(5);
-}
 
 macro_rules! macro_newtype {
     ($name:ident) => {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -33,8 +33,5 @@ mod issue_547;
 #[path = "issues/issue_570.rs"]
 mod issue_570;
 
-#[path = "issues/issue_592.rs"]
-mod issue_592;
-
 #[path = "issues/issue_614.rs"]
 mod issue_614;

--- a/tests/issues/issue_592.rs
+++ b/tests/issues/issue_592.rs
@@ -1,8 +1,0 @@
-#![cfg(all(feature = "derive", feature = "std"))]
-
-use bincode::{Decode, Encode};
-
-#[derive(Encode, Decode)]
-pub enum TypeOfFile {
-    Unknown = -1,
-}


### PR DESCRIPTION
When a enum variant had no explicit discriminant, there was a try to calculate it by looking at the previous one.
This was not working at all:
- the first enum variant was never looked at
- when finding an enum variant with a discriminant, it was taking its value + 1 (even if it was not the immediate previous one).

This commit corrects the logic to make it work.